### PR TITLE
Fix build errors

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -263,6 +263,7 @@ for what in "$@"; do
     desired[${what}]=Yes
 done
 
+unset $(set +x; env | awk -F= '/^(PMI|SLURM)_/ {print $1}' | xargs)
 
 [[ ${do_generate} != "no" ]] && generate_specs "$@"
 for what in ${stages}; do

--- a/deploy.sh
+++ b/deploy.sh
@@ -191,7 +191,7 @@ install_specs() {
     populate_mirror "${what}"
 
     log "gathering specs"
-    spec_list=$(spack filter --not-installed $(cat ${HOME}/specs.txt))
+    spec_list=$(spack filter --not-installed $(< ${HOME}/specs.txt))
 
     if [[ -z "${spec_list}" ]]; then
         log "...found no new packages"

--- a/deploy.sh
+++ b/deploy.sh
@@ -145,7 +145,7 @@ generate_specs() {
         rm -f "${datadir}/specs.txt"
         for stub in ${spec_definitions[$stage]}; do
             log "...using ${stub}.yaml"
-            spackd --input packages/${stub}.yaml packages x86_64 > "${datadir}/specs.txt"
+            spackd --input packages/${stub}.yaml packages x86_64 >> "${datadir}/specs.txt"
         done
     done
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -89,7 +89,7 @@ populate_mirror() {
 
     if [[ -z "${spec_list}" ]]; then
         log "...found no new packages"
-        return 1
+        return 0
     fi
 
     if [[ "${what}" = "compilers" ]]; then
@@ -195,7 +195,7 @@ install_specs() {
 
     if [[ -z "${spec_list}" ]]; then
         log "...found no new packages"
-        return 1
+        return 0
     else
         log "found the following specs"
         echo "${spec_list}"
@@ -207,6 +207,7 @@ install_specs() {
     fi
 
     spack module tcl refresh --delete-tree -y
+    . ${DEPLOYMENT_ROOT}/deploy/spack/share/spack/setup-env.sh
     spack export --scope=user --explicit --module tcl > "${HOME}/packages.yaml"
 
     if [[ "${what}" == "compilers" && -n "${spec_list}" ]]; then

--- a/packages/parallel-libraries.yaml
+++ b/packages/parallel-libraries.yaml
@@ -23,7 +23,7 @@ packages:
       - highfive@1.6
       - matio@1.5.9
       - netcdf@4.6.1
-      - omega-h@9.22.1
+      - omega-h@9.22.2
       - parmetis@4.0.3
 
   gnu-stable-parallel-lapack:


### PR DESCRIPTION
@matz-e  : while testing `deploy.sh` I see following issues:

* I have seen weird errors like:

```
==> Error: Multiple providers found for 'mpi': ['hpe-mpi@2.16 arch=linux-None-x86_64  ^openblas@0.3.3 ^python@3.6.5', 'intel-parallel-studio@cluster.2018.3%gcc@6.4.0+advisor+clck+daal+gdb~ilp64+inspector+ipp+itac+mkl+mpi~newdtags+rpath+shared+tbb threads=none +vtune arch=linux-rhel7-x86_64']
```

This is because of passing string/double-quote arguments to spack install, e.g.:

```
spack install -y --log-format=junit --log-file="${HOME}/stack.xml" "${spec_list}"  => generate error
```

vs.

```
spack install -y --log-format=junit --log-file="${HOME}/stack.xml" ${spec_list}
```

* passing output of `spack filter` across the functions (as string?) also causing weird errors

Until libraries everything is built expect `py-arrow`. 

* why are we adding both path as well as module in packages.yaml? Path is sufficient I believe.

```
  intel-parallel-studio:
    paths:
      intel-parallel-studio@cluster.2018.3 +advisor+clck+gdb+inspector+itac+vtune: /gpfs/bbp.cscs.ch/apps/hpc/test/kumbhar/deploy_test/install/compilers/2018-11-20/linux-rhel7-x86_64/gcc-4.8.5/intel-parallel-studio-cluster.2018.3-b6hcs36ftv
    modules:
      intel-parallel-studio@cluster.2018.3 +advisor+clck+gdb+inspector+itac+vtune: intel-parallel-studio/cluster.2018.3
```

* When I started everything from scratch again, I have seen this:

```
=> py-setuptools@40.2.0 : marking the package explicit
==> Nothing to be done for tcl module files.
==> Warning: python package not activated, skipping: py-lit@0.5.0
==> Warning: python package not activated, skipping: py-setuptools@40.2.0
### copying configuration
### ...into /gpfs/bbp.cscs.ch/apps/hpc/test/kumbhar/deploy_test/install/libraries/2018-11-21/data
### ...using configuration output of tools
### sourcing spack environment
### populating mirror for libraries
==> Error: No compilers with spec intel@18.0.3 found
Run 'spack compiler find' to add compilers.
### ...found no new packages
### gathering specs
==> Error: No compilers with spec intel@18.0.3 found
Run 'spack compiler find' to add compilers.
### ...found no new packages
### copying configuration
### ...into /gpfs/bbp.cscs.ch/apps/hpc/test/kumbhar/deploy_test/install/applications/2018-11-21/data
### ...using configuration output of libraries
cp: cannot stat ‘/gpfs/bbp.cscs.ch/apps/hpc/test/kumbhar/deploy_test/install/libraries/2018-11-21/data/packages.yaml’: No such file or directory
cp: cannot stat ‘/gpfs/bbp.cscs.ch/apps/hpc/test/kumbhar/deploy_test/install/libraries/2018-11-21/data/compile
```
this is because when we start fresh (with `0` modules), spack will install all compilers and generate the modules.  When we do `module load` in `configure_compilers`, MODULEPATH is not updated. We have re-source `spack/setup-env.sh`